### PR TITLE
feat(movies): add create controller

### DIFF
--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const Movie = require('../../../models/movie');
+
+exports.create = async (payload) => {
+  const movie = await new Movie().save(payload);
+
+  return new Movie({ id: movie.id }).fetch();
+};

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const MovieValidator = require('../../../validators/movie');
+const Controller = require('./controller');
 
 exports.register = (server, options, next) => {
 
@@ -9,7 +10,7 @@ exports.register = (server, options, next) => {
     path: '/movies',
     config: {
       handler: (request, reply) => {
-        reply('hello world');
+        reply(Controller.create(request.payload));
       },
       validate: {
         payload: MovieValidator

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const MovieValidator = require('../../../validators/movie');
+
 const Controller = require('./controller');
 
 exports.register = (server, options, next) => {

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const Controller = require('../../../../lib/plugins/features/movies/controller');
+
+describe('movie controller', () => {
+  
+  describe('create', () => {
+    
+    it('creates a movie', async () => {
+      const payload = { title: 'Forrest Gump' };
+      
+      const movie = await Controller.create(payload);
+
+      expect(movie.get('title')).to.eql(payload.title);
+    });
+
+  });
+
+});

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -3,12 +3,12 @@
 const Controller = require('../../../../lib/plugins/features/movies/controller');
 
 describe('movie controller', () => {
-  
+
   describe('create', () => {
-    
+
     it('creates a movie', async () => {
       const payload = { title: 'Forrest Gump' };
-      
+
       const movie = await Controller.create(payload);
 
       expect(movie.get('title')).to.eql(payload.title);

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -6,16 +6,14 @@ describe('movies integration', () => {
 
   describe('create', () => {
 
-    it('creates a movie', () => {
-      return Movies.inject({
+    it('creates a movie', async () => {
+      const response = await Movies.inject({
         url: '/movies',
         method: 'POST',
         payload: { title: 'Volver' }
-      })
-      .then((response) => {
-        expect(response.statusCode).to.eql(200);
-        expect(response.result.object).to.eql('movie');
       });
+      expect(response.statusCode).to.eql(200);
+      expect(response.result.object).to.eql('movie');
     });
 
   });

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const Movies = require('../../../../lib/server');
+
+describe('movies integration', () => {
+
+  describe('create', () => {
+
+    it('creates a movie', () => {
+      return Movies.inject({
+        url: '/movies',
+        method: 'POST',
+        payload: { title: 'Volver' }
+      })
+      .then((response) => {
+        expect(response.statusCode).to.eql(200);
+        expect(response.result.object).to.eql('movie');
+      });
+    });
+
+  });
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3249,9 +3249,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 uglify-js@^3.1.4:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.2.tgz#dc0c7ac2da0a4b7d15e84266818ff30e82529474"
-  integrity sha512-imog1WIsi9Yb56yRt5TfYVxGmnWs3WSGU73ieSOlMVFwhJCA9W8fqFFMMj4kgDqiS/80LGdsYnWL7O9UcjEBlg==
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.3.tgz#d490bb5347f23025f0c1bc0dee901d98e4d6b063"
+  integrity sha512-rIQPT2UMDnk4jRX+w4WO84/pebU2jiLsjgIyrCktYgSvx28enOE3iYQMr+BD1rHiitWnDmpu0cY/LfIEpKcjcw==
   dependencies:
     commander "~2.19.0"
     source-map "~0.6.1"


### PR DESCRIPTION
**What:** Implements a controller that controls the creation of new movies in the DB when POST requests are made to the /movies endpoint.

**Why:** This provides the client with the ability to use the API to store movies.

**Details:**
Includes a controller to load movie info into the DB.
Implements unit tests and integration tests to ensure the proper functioning of the controller and the /movies endpoint as a whole.