### PR TITLE
 feat(movies): get movies with filters

### DIFF
--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -23,13 +23,13 @@ exports.find = (params) => {
     if (params.title) {
       qb.where('title', '=', params.title);
     }
-    if (params.orderBy === 'year') {
-      params.orderBy = 'release_year';
+    if (params.order_by === 'year') {
+      params.order_by = 'release_year';
     }
-    if (params.orderBy && params.order) {
-      qb.orderBy(params.orderBy, params.order);
-    } else if (params.orderBy) {
-      qb.orderBy(params.orderBy);
+    if (params.order_by && params.order) {
+      qb.orderBy(params.order_by, params.order);
+    } else if (params.order_by) {
+      qb.orderBy(params.order_by);
     } else if (params.order) {
       qb.orderBy('id', params.order);
     }

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -7,3 +7,27 @@ exports.create = async (payload) => {
 
   return new Movie({ id: movie.id }).fetch();
 };
+
+exports.find = (params) => {
+  const qb = new Movie().query();
+  if (params.year) {
+    qb.where('release_year', '=', params.year);
+  }
+  if (params.start_yr) {
+    qb.where('release_year', '>=', params.start_yr);
+  }
+  if (params.end_yr) {
+    qb.where('release_year', '<=', params.end_yr);
+  }
+  if (params.title) {
+    qb.where('title', '=', params.title);
+  }
+  if (params.orderBy && params.order) {
+    qb.orderBy(params.orderBy, params.order);
+  } else if (params.orderBy) {
+    qb.orderBy(params.orderBy);
+  } else if (params.order) {
+    qb.orderBy('id', params.order);
+  }
+  return qb;
+};

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -10,24 +10,29 @@ exports.create = async (payload) => {
 
 exports.find = (params) => {
   const qb = new Movie().query();
-  if (params.year) {
-    qb.where('release_year', '=', params.year);
-  }
-  if (params.start_yr) {
-    qb.where('release_year', '>=', params.start_yr);
-  }
-  if (params.end_yr) {
-    qb.where('release_year', '<=', params.end_yr);
-  }
-  if (params.title) {
-    qb.where('title', '=', params.title);
-  }
-  if (params.orderBy && params.order) {
-    qb.orderBy(params.orderBy, params.order);
-  } else if (params.orderBy) {
-    qb.orderBy(params.orderBy);
-  } else if (params.order) {
-    qb.orderBy('id', params.order);
+  if (params) {
+    if (params.year) {
+      qb.where('release_year', '=', params.year);
+    }
+    if (params.start_yr) {
+      qb.where('release_year', '>=', params.start_yr);
+    }
+    if (params.end_yr) {
+      qb.where('release_year', '<=', params.end_yr);
+    }
+    if (params.title) {
+      qb.where('title', '=', params.title);
+    }
+    if (params.orderBy === 'year') {
+      params.orderBy = 'release_year';
+    }
+    if (params.orderBy && params.order) {
+      qb.orderBy(params.orderBy, params.order);
+    } else if (params.orderBy) {
+      qb.orderBy(params.orderBy);
+    } else if (params.order) {
+      qb.orderBy('id', params.order);
+    }
   }
   return qb;
 };

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -9,30 +9,32 @@ exports.create = async (payload) => {
 };
 
 exports.find = (params) => {
-  const qb = new Movie().query();
-  if (params) {
-    if (params.year) {
-      qb.where('release_year', '=', params.year);
+  return new Movie()
+  .query((qb) => {
+    if (params) {
+      if (params.year) {
+        qb.where('release_year', '=', params.year);
+      }
+      if (params.start_yr) {
+        qb.where('release_year', '>=', params.start_yr);
+      }
+      if (params.end_yr) {
+        qb.where('release_year', '<=', params.end_yr);
+      }
+      if (params.title) {
+        qb.where('title', '=', params.title);
+      }
+      if (params.order_by === 'year') {
+        params.order_by = 'release_year';
+      }
+      if (params.order_by && params.order) {
+        qb.orderBy(params.order_by, params.order);
+      } else if (params.order_by) {
+        qb.orderBy(params.order_by);
+      } else if (params.order) {
+        qb.orderBy('id', params.order);
+      }
     }
-    if (params.start_yr) {
-      qb.where('release_year', '>=', params.start_yr);
-    }
-    if (params.end_yr) {
-      qb.where('release_year', '<=', params.end_yr);
-    }
-    if (params.title) {
-      qb.where('title', '=', params.title);
-    }
-    if (params.order_by === 'year') {
-      params.order_by = 'release_year';
-    }
-    if (params.order_by && params.order) {
-      qb.orderBy(params.order_by, params.order);
-    } else if (params.order_by) {
-      qb.orderBy(params.order_by);
-    } else if (params.order) {
-      qb.orderBy('id', params.order);
-    }
-  }
-  return qb;
+  })
+  .fetchAll();
 };

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -2,6 +2,8 @@
 
 const MovieValidator = require('../../../validators/movie');
 
+const QueryValidator = require('../../../validators/query');
+
 const Controller = require('./controller');
 
 exports.register = (server, options, next) => {
@@ -15,6 +17,17 @@ exports.register = (server, options, next) => {
       },
       validate: {
         payload: MovieValidator
+      }
+    }
+  }, {
+    method: 'GET',
+    path: '/movies',
+    config: {
+      handler: (request, reply) => {
+        reply(Controller.find(request.query));
+      },
+      validate: {
+        query: QueryValidator
       }
     }
   }]);

--- a/lib/validators/query.js
+++ b/lib/validators/query.js
@@ -7,6 +7,6 @@ module.exports = Joi.object().keys({
   start_yr: Joi.number().integer().min(1878).max(9999).optional(),
   end_yr: Joi.number().integer().min(1878).max(9999).optional(),
   title: Joi.string().min(1).max(255).optional(),
-  orderBy: Joi.string().valid('year', 'title', 'id').optional(),
+  order_by: Joi.string().valid('year', 'title', 'id').optional(),
   order: Joi.string().valid('asc', 'desc').optional()
 });

--- a/lib/validators/query.js
+++ b/lib/validators/query.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const Joi = require('joi');
+
+module.exports = Joi.object().keys({
+  year: Joi.number().integer().min(1878).max(9999).optional(),
+  start_yr: Joi.number().integer().min(1878).max(9999).optional(),
+  end_yr: Joi.number().integer().min(1878).max(9999).optional(),
+  title: Joi.string().min(1).max(255).optional(),
+  orderBy: Joi.string().valid('year', 'title', 'id').optional(),
+  order: Joi.string().valid('asc', 'desc').optional()
+});

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -38,7 +38,7 @@ describe('movie controller', () => {
 
   describe('find', () => {
 
-    it('finds a movie', async () => {
+    it('finds a movie w/o params', async () => {
       const movies = await Controller.find();
       expect(movies.length).to.eql(2);
       expect(movies[0].title).to.eql(firstMovie.title);
@@ -47,7 +47,7 @@ describe('movie controller', () => {
       expect(movies[1].release_year).to.eql(secondMovie.release_year);
     });
 
-    it('finds a movie with query params (order)', async () => {
+    it('finds a movie with order param', async () => {
       const params = {
         title: secondMovie.title,
         year: secondMovie.release_year,
@@ -63,14 +63,14 @@ describe('movie controller', () => {
       expect(movies[0].release_year).to.eql(secondMovie.release_year);
     });
 
-    it('finds a movie with query params (order & orderBy)', async () => {
+    it('finds a movie with order & order_by params', async () => {
       const params = {
         title: secondMovie.title,
         year: secondMovie.release_year,
         start_yr: firstMovie.release_year,
         end_yr: 1995,
         order: 'desc',
-        orderBy: 'title'
+        order_by: 'title'
       };
 
       const movies = await Controller.find(params);
@@ -80,13 +80,13 @@ describe('movie controller', () => {
       expect(movies[0].release_year).to.eql(secondMovie.release_year);
     });
 
-    it('finds a movie with query params (orderBy)', async () => {
+    it('finds a movie with order_by param', async () => {
       const params = {
         title: secondMovie.title,
         year: secondMovie.release_year,
         start_yr: firstMovie.release_year,
         end_yr: 1995,
-        orderBy: 'year'
+        order_by: 'year'
       };
 
       const movies = await Controller.find(params);

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -32,7 +32,6 @@ describe('movie controller', () => {
       const movie = await Controller.create(payload);
 
       expect(movie.get('title')).to.eql(payload.title);
-      await new Movie().query().where('title', 'Forrest Gump').del();
     });
 
   });
@@ -40,12 +39,12 @@ describe('movie controller', () => {
   describe('find', () => {
 
     it('finds a movie w/o params', async () => {
-      const movies = await Controller.find();
+      const movies = await Controller.find().get('models');
       expect(movies.length).to.eql(2);
-      expect(movies[0].title).to.eql(firstMovie.title);
-      expect(movies[0].release_year).to.eql(firstMovie.release_year);
-      expect(movies[1].title).to.eql(secondMovie.title);
-      expect(movies[1].release_year).to.eql(secondMovie.release_year);
+      expect(movies[0].get('title')).to.eql(firstMovie.title);
+      expect(movies[0].get('release_year')).to.eql(firstMovie.release_year);
+      expect(movies[1].get('title')).to.eql(secondMovie.title);
+      expect(movies[1].get('release_year')).to.eql(secondMovie.release_year);
     });
 
     it('finds a movie with order param', async () => {
@@ -57,11 +56,10 @@ describe('movie controller', () => {
         order: 'asc'
       };
 
-      const movies = await Controller.find(params);
-
+      const movies = await Controller.find(params).get('models');
       expect(movies.length).to.eql(1);
-      expect(movies[0].title).to.eql(secondMovie.title);
-      expect(movies[0].release_year).to.eql(secondMovie.release_year);
+      expect(movies[0].get('title')).to.eql(secondMovie.title);
+      expect(movies[0].get('release_year')).to.eql(secondMovie.release_year);
     });
 
     it('finds a movie with order & order_by params', async () => {
@@ -74,11 +72,11 @@ describe('movie controller', () => {
         order_by: 'title'
       };
 
-      const movies = await Controller.find(params);
+      const movies = await Controller.find(params).get('models');
 
       expect(movies.length).to.eql(1);
-      expect(movies[0].title).to.eql(secondMovie.title);
-      expect(movies[0].release_year).to.eql(secondMovie.release_year);
+      expect(movies[0].get('title')).to.eql(secondMovie.title);
+      expect(movies[0].get('release_year')).to.eql(secondMovie.release_year);
     });
 
     it('finds a movie with order_by param', async () => {
@@ -90,10 +88,10 @@ describe('movie controller', () => {
         order_by: 'year'
       };
 
-      const movies = await Controller.find(params);
+      const movies = await Controller.find(params).get('models');
 
-      expect(movies[0].title).to.eql(secondMovie.title);
-      expect(movies[0].release_year).to.eql(secondMovie.release_year);
+      expect(movies[0].get('title')).to.eql(secondMovie.title);
+      expect(movies[0].get('release_year')).to.eql(secondMovie.release_year);
       expect(movies.length).to.eql(1);
     });
 

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -2,7 +2,39 @@
 
 const Controller = require('../../../../lib/plugins/features/movies/controller');
 
+const Movie = require('../../../../lib/models/movie');
+
 describe('movie controller', () => {
+
+  const firstTitle = 'test movie 1';
+  const firstYear = 1985;
+  const secondTitle = 'test movie 2';
+  const secondYear = 1990;
+
+  before('Setting up the test DB', async () => {
+    await new Movie().query().del();
+
+    const firstPayload = {
+      title: firstTitle,
+      release_year: firstYear
+    };
+
+    const secondPayload = {
+      title: secondTitle,
+      release_year: secondYear
+    };
+
+    Controller.create(firstPayload);
+    Controller.create(secondPayload);
+  });
+
+  after('Deleting the test DB', async () => {
+    await new Movie().query().del();
+  });
+
+  afterEach('deletes Forrest Gump', async () => {
+    await new Movie().query().where('title', 'Forrest Gump').del();
+  });
 
   describe('create', () => {
 
@@ -12,6 +44,68 @@ describe('movie controller', () => {
       const movie = await Controller.create(payload);
 
       expect(movie.get('title')).to.eql(payload.title);
+    });
+
+  });
+
+  describe('find', () => {
+
+    it('finds a movie', async () => {
+      const movies = await Controller.find();
+      expect(movies[0].title).to.eql(firstTitle);
+      expect(movies[0].release_year).to.eql(firstYear);
+      expect(movies[1].title).to.eql(secondTitle);
+      expect(movies[1].release_year).to.eql(secondYear);
+      expect(movies.length).to.eql(2);
+    });
+
+    it('finds a movie with query params (order)', async () => {
+      const params = {
+        title: secondTitle,
+        year: secondYear,
+        start_yr: firstYear,
+        end_yr: 1995,
+        order: 'asc'
+      };
+
+      const movies = await Controller.find(params);
+
+      expect(movies[0].title).to.eql(secondTitle);
+      expect(movies[0].release_year).to.eql(secondYear);
+      expect(movies.length).to.eql(1);
+    });
+
+    it('finds a movie with query params (order & orderBy)', async () => {
+      const params = {
+        title: secondTitle,
+        year: secondYear,
+        start_yr: firstYear,
+        end_yr: 1995,
+        order: 'desc',
+        orderBy: 'title'
+      };
+
+      const movies = await Controller.find(params);
+
+      expect(movies[0].title).to.eql(secondTitle);
+      expect(movies[0].release_year).to.eql(secondYear);
+      expect(movies.length).to.eql(1);
+    });
+
+    it('finds a movie with query params (orderBy)', async () => {
+      const params = {
+        title: secondTitle,
+        year: secondYear,
+        start_yr: firstYear,
+        end_yr: 1995,
+        orderBy: 'year'
+      };
+
+      const movies = await Controller.find(params);
+
+      expect(movies[0].title).to.eql(secondTitle);
+      expect(movies[0].release_year).to.eql(secondYear);
+      expect(movies.length).to.eql(1);
     });
 
   });

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -4,6 +4,8 @@ const Controller = require('../../../../lib/plugins/features/movies/controller')
 
 const Movie = require('../../../../lib/models/movie');
 
+const Knex = require('../../../../lib/libraries/knex');
+
 describe('movie controller', () => {
 
   const firstMovie = {
@@ -16,11 +18,10 @@ describe('movie controller', () => {
     release_year: 1990
   };
 
-  before('Setting up the test DB', async () => {
-    await new Movie().query().del();
-
-    Controller.create(firstMovie);
-    Controller.create(secondMovie);
+  beforeEach('Setting up the test DB', async () => {
+    await Knex.raw('TRUNCATE movies CASCADE');
+    await new Movie().save(firstMovie);
+    await new Movie().save(secondMovie);
   });
 
   describe('create', () => {

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -6,34 +6,21 @@ const Movie = require('../../../../lib/models/movie');
 
 describe('movie controller', () => {
 
-  const firstTitle = 'test movie 1';
-  const firstYear = 1985;
-  const secondTitle = 'test movie 2';
-  const secondYear = 1990;
+  const firstMovie = {
+    title: 'test movie 1',
+    release_year: 1985
+  };
+
+  const secondMovie = {
+    title: 'test movie 2',
+    release_year: 1990
+  };
 
   before('Setting up the test DB', async () => {
     await new Movie().query().del();
 
-    const firstPayload = {
-      title: firstTitle,
-      release_year: firstYear
-    };
-
-    const secondPayload = {
-      title: secondTitle,
-      release_year: secondYear
-    };
-
-    Controller.create(firstPayload);
-    Controller.create(secondPayload);
-  });
-
-  after('Deleting the test DB', async () => {
-    await new Movie().query().del();
-  });
-
-  afterEach('deletes Forrest Gump', async () => {
-    await new Movie().query().where('title', 'Forrest Gump').del();
+    Controller.create(firstMovie);
+    Controller.create(secondMovie);
   });
 
   describe('create', () => {
@@ -44,6 +31,7 @@ describe('movie controller', () => {
       const movie = await Controller.create(payload);
 
       expect(movie.get('title')).to.eql(payload.title);
+      await new Movie().query().where('title', 'Forrest Gump').del();
     });
 
   });
@@ -52,34 +40,34 @@ describe('movie controller', () => {
 
     it('finds a movie', async () => {
       const movies = await Controller.find();
-      expect(movies[0].title).to.eql(firstTitle);
-      expect(movies[0].release_year).to.eql(firstYear);
-      expect(movies[1].title).to.eql(secondTitle);
-      expect(movies[1].release_year).to.eql(secondYear);
       expect(movies.length).to.eql(2);
+      expect(movies[0].title).to.eql(firstMovie.title);
+      expect(movies[0].release_year).to.eql(firstMovie.release_year);
+      expect(movies[1].title).to.eql(secondMovie.title);
+      expect(movies[1].release_year).to.eql(secondMovie.release_year);
     });
 
     it('finds a movie with query params (order)', async () => {
       const params = {
-        title: secondTitle,
-        year: secondYear,
-        start_yr: firstYear,
+        title: secondMovie.title,
+        year: secondMovie.release_year,
+        start_yr: firstMovie.release_year,
         end_yr: 1995,
         order: 'asc'
       };
 
       const movies = await Controller.find(params);
 
-      expect(movies[0].title).to.eql(secondTitle);
-      expect(movies[0].release_year).to.eql(secondYear);
       expect(movies.length).to.eql(1);
+      expect(movies[0].title).to.eql(secondMovie.title);
+      expect(movies[0].release_year).to.eql(secondMovie.release_year);
     });
 
     it('finds a movie with query params (order & orderBy)', async () => {
       const params = {
-        title: secondTitle,
-        year: secondYear,
-        start_yr: firstYear,
+        title: secondMovie.title,
+        year: secondMovie.release_year,
+        start_yr: firstMovie.release_year,
         end_yr: 1995,
         order: 'desc',
         orderBy: 'title'
@@ -87,24 +75,24 @@ describe('movie controller', () => {
 
       const movies = await Controller.find(params);
 
-      expect(movies[0].title).to.eql(secondTitle);
-      expect(movies[0].release_year).to.eql(secondYear);
       expect(movies.length).to.eql(1);
+      expect(movies[0].title).to.eql(secondMovie.title);
+      expect(movies[0].release_year).to.eql(secondMovie.release_year);
     });
 
     it('finds a movie with query params (orderBy)', async () => {
       const params = {
-        title: secondTitle,
-        year: secondYear,
-        start_yr: firstYear,
+        title: secondMovie.title,
+        year: secondMovie.release_year,
+        start_yr: firstMovie.release_year,
         end_yr: 1995,
         orderBy: 'year'
       };
 
       const movies = await Controller.find(params);
 
-      expect(movies[0].title).to.eql(secondTitle);
-      expect(movies[0].release_year).to.eql(secondYear);
+      expect(movies[0].title).to.eql(secondMovie.title);
+      expect(movies[0].release_year).to.eql(secondMovie.release_year);
       expect(movies.length).to.eql(1);
     });
 

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -18,4 +18,17 @@ describe('movies integration', () => {
 
   });
 
+  describe('find', () => {
+
+    it('finds all movies', async () => {
+      const response = await Movies.inject({
+        url: '/movies',
+        method: 'GET'
+      });
+      expect(response.statusCode).to.eql(200);
+      expect(response.result).to.be.an('array');
+    });
+
+  });
+
 });

--- a/test/validators/query.test.js
+++ b/test/validators/query.test.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const Joi = require('joi');
+
+const QueryValidator = require('../../lib/validators/query');
+
+describe('query validator', () => {
+
+  describe('year', () => {
+
+    it('is after 1878', () => {
+      const payload = {
+        year: 1800
+      };
+      const result = Joi.validate(payload, QueryValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('year');
+      expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+    it('is limited to 4 digits', () => {
+      const payload = {
+        year: 11111
+      };
+      const result = Joi.validate(payload, QueryValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('year');
+      expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+  });
+
+  describe('start_yr', () => {
+
+    it('is after 1878', () => {
+      const payload = {
+        start_yr: 1800
+      };
+      const result = Joi.validate(payload, QueryValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('start_yr');
+      expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+    it('is limited to 4 digits', () => {
+      const payload = {
+        start_yr: 11111
+      };
+      const result = Joi.validate(payload, QueryValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('start_yr');
+      expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+  });
+
+  describe('end_yr', () => {
+
+    it('is after 1878', () => {
+      const payload = {
+        end_yr: 1800
+      };
+      const result = Joi.validate(payload, QueryValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('end_yr');
+      expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+    it('is limited to 4 digits', () => {
+      const payload = {
+        end_yr: 11111
+      };
+      const result = Joi.validate(payload, QueryValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('end_yr');
+      expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+  });
+
+  describe('title', () => {
+
+    it('is less than 255 characters', () => {
+      const payload = { title: 'a'.repeat(256) };
+      const result = Joi.validate(payload, QueryValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('title');
+      expect(result.error.details[0].type).to.eql('string.max');
+    });
+
+  });
+
+  describe('orderBy', () => {
+
+    it('only allows db columns', () => {
+      const payload = { orderBy: 'invalid db column' };
+      const result = Joi.validate(payload, QueryValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('orderBy');
+      expect(result.error.details[0].type).to.eql('any.allowOnly');
+    });
+
+  });
+
+  describe('order', () => {
+
+    it('only allows asc/desc', () => {
+      const payload = { order: 'invalid order' };
+      const result = Joi.validate(payload, QueryValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('order');
+      expect(result.error.details[0].type).to.eql('any.allowOnly');
+    });
+
+  });
+
+});

--- a/test/validators/query.test.js
+++ b/test/validators/query.test.js
@@ -90,13 +90,13 @@ describe('query validator', () => {
 
   });
 
-  describe('orderBy', () => {
+  describe('order_by', () => {
 
     it('only allows db columns', () => {
-      const payload = { orderBy: 'invalid db column' };
+      const payload = { order_by: 'invalid db column' };
       const result = Joi.validate(payload, QueryValidator);
 
-      expect(result.error.details[0].path[0]).to.eql('orderBy');
+      expect(result.error.details[0].path[0]).to.eql('order_by');
       expect(result.error.details[0].type).to.eql('any.allowOnly');
     });
 


### PR DESCRIPTION
**What:** Implements a GET route, controller method, and a related validator that provides a certain subset of all movies when GET requests are made to the /movies endpoint.

**Why:** This provides the client with the ability to use the API to get information about stored movies.

**Details:**
Creates a route to allow the client to send GET requests to the /movies endpoint.
Includes a controller method to get movie info from the DB. This controller filters information based on query params given to the user (year, start_yr, end_yr, title, order_by, and order).
Includes a validator that validates the query params provided by the user when making the GET request.
Implements unit tests and integration tests to ensure the proper functioning of the controller, validator, and the /movies endpoint as a whole.