### PR TITLE
chore(migration): add name column

### DIFF
--- a/db/migrations/20190408160753_add_name_to_movies.js
+++ b/db/migrations/20190408160753_add_name_to_movies.js
@@ -7,7 +7,7 @@ exports.up = async (Knex) => {
   await Knex.raw('ALTER TABLE movies ALTER COLUMN title DROP NOT NULL');
 };
 
- exports.down = async (Knex) => {
+exports.down = async (Knex) => {
   await Knex.schema.table('movies', (table) => {
     table.dropColumn('name');
   });

--- a/db/migrations/20190408160753_add_name_to_movies.js
+++ b/db/migrations/20190408160753_add_name_to_movies.js
@@ -1,0 +1,15 @@
+'use strict';
+
+exports.up = async (Knex) => {
+  await Knex.schema.table('movies', (table) => {
+    table.text('name');
+  });
+  await Knex.raw('ALTER TABLE movies ALTER COLUMN title DROP NOT NULL');
+};
+
+ exports.down = async (Knex) => {
+  await Knex.schema.table('movies', (table) => {
+    table.dropColumn('name');
+  });
+  await Knex.raw('ALTER TABLE movies ALTER COLUMN title SET NOT NULL');
+};


### PR DESCRIPTION
**What:** Implements a migration to the movies table to add a name column and make the title column nullable.

**Why:** This provides the foundation for a full migration to the name column from the title column.

**Details:**
Includes a simple migration script that add a name column and make the title column nullable in the movies table.