### PR TITLE
chore(migration): save and backfill name column

### DIFF
--- a/db/migrations/20190408163552_backfill_movies_name.js
+++ b/db/migrations/20190408163552_backfill_movies_name.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.raw('UPDATE movies SET name = title');
+};
+
+exports.down = (Knex, Promise) => {
+  return Promise.resolve();
+};

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -9,6 +9,7 @@ const MOVIE_FETCH_OPTIONS = {
 };
 
 exports.createMovie = async (payload) => {
+  payload.name = payload.title;
   const movie = await new Movie().save(payload);
 
   return new Movie({ id: movie.id }).fetch(MOVIE_FETCH_OPTIONS);


### PR DESCRIPTION
**What:** Implements a migration to the movies table to backfill the name column with the respective title column values and adjusts application code to store new movie titles in both the title and name columns.

**Why:** This provides the foundation for a full migration to the name column from the title column.

**Details:**
Includes a simple migration script to backfill the name column with the respective title column values.
Adjusts application code to store new movie titles in both the title and name columns.